### PR TITLE
Adding jtds provider for sql server

### DIFF
--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/sql/PreparedStatementClassDataProvider.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/sql/PreparedStatementClassDataProvider.java
@@ -69,6 +69,9 @@ public final class PreparedStatementClassDataProvider {
             factory = classFactoryForSqlServer();
             doAdd(factory, "com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement");
 
+            factory = classFactoryForJtdsSqlServer();
+            doAdd(factory, "net/sourceforge/jtds/jdbc/JtdsPreparedStatement");
+
             addSqlite();
         } catch (Throwable t) {
             InternalAgentLogger.INSTANCE.error("Exception while loading HTTP classes: '%s'", t.getMessage());
@@ -253,6 +256,22 @@ public final class PreparedStatementClassDataProvider {
                 HashSet<String> ctorSignatures = new HashSet<String>();
                 ctorSignatures.add("(Lcom/microsoft/sqlserver/jdbc/SQLServerConnection;Ljava/lang/String;" +
                         "IILcom/microsoft/sqlserver/jdbc/SQLServerStatementColumnEncryptionSetting;)V");
+                final PreparedStatementMetaData metaData1 = new PreparedStatementMetaData(ctorSignatures);
+                metaData1.sqlStringInCtor = 2;
+                return new PreparedStatementClassVisitor(classInstrumentationData, classWriter, metaData1);
+            }
+        };
+
+        return classVisitorFactory;
+    }
+
+    private ClassVisitorFactory classFactoryForJtdsSqlServer() {
+
+        ClassVisitorFactory classVisitorFactory = new ClassVisitorFactory() {
+            @Override
+            public ClassVisitor create(ClassInstrumentationData classInstrumentationData, ClassWriter classWriter) {
+                HashSet<String> ctorSignatures = new HashSet<String>();
+                ctorSignatures.add("(Lnet/sourceforge/jtds/jdbc/ConnectionJDBC2;Ljava/lang/String;IIZ)V");
                 final PreparedStatementMetaData metaData1 = new PreparedStatementMetaData(ctorSignatures);
                 metaData1.sqlStringInCtor = 2;
                 return new PreparedStatementClassVisitor(classInstrumentationData, classWriter, metaData1);

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/sql/StatementClassDataDataProvider.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/sql/StatementClassDataDataProvider.java
@@ -42,7 +42,8 @@ public class StatementClassDataDataProvider {
             "com/microsoft/sqlserver/jdbc/SQLServerStatement",
             "org/apache/derby/client/am/Statement",
             "org/apache/derby/client/am/ClientStatement",
-            "org/sqlite/jdbc3/JDBC3Statement"
+            "org/sqlite/jdbc3/JDBC3Statement",
+            "net/sourceforge/jtds/jdbc/JtdsStatement"
     };
 
     private final Map<String, ClassInstrumentationData> classesToInstrument;


### PR DESCRIPTION
Enhancement: added support for jtds msql driver. Jtds is considered better implementation by Microsoft one in many places in java community. It is went through full e2e test locally on our application running in jboss.

<img width="1141" alt="screen shot 2018-02-07 at 23 59 01" src="https://user-images.githubusercontent.com/252896/35943859-2488fed2-0c63-11e8-9e48-25ba63aa3af3.png">